### PR TITLE
add emacs backup format to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 # This file isn't used by the Rails Composer application template; instead the template uses:
 # https://github.com/RailsApps/rails-composer/blob/master/files/gitignore.txt
 #
-# Corrections? Improvements? Create a GitHub issue: 
+# Corrections? Improvements? Create a GitHub issue:
 # http://github.com/RailsApps/rails-composer/issues
 #----------------------------------------------------------------------------
 
@@ -77,3 +77,6 @@ pickle-email-*.html
 
 # vim artifacts
 **.swp
+
+# emacs backup
+*~


### PR DESCRIPTION
- emacsのbackupが混ざるので追加したいです。
- 13行目にスペース入っていたみたいですが気にしないで下さい。
